### PR TITLE
fix: add explicit dependency submission workflow for Python 3.14

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,23 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: ["mainline"]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          allow-prereleases: true
+
+      - name: Submit Python dependencies
+        uses: actions/dependency-submission@v1


### PR DESCRIPTION
The **Automatic Dependency Submission (Python)** workflow fails because it runs `pip-compile` on Python 3.12 (GHA default). All `kuhl-haus-mdp` releases ≥0.1.17 require Python ≥3.14, so pip-compile cannot resolve the pinned version.

This PR adds an explicit `.github/workflows/dependency-submission.yml` that sets up Python 3.14 before submitting dependencies. GitHub uses the custom workflow instead of the auto-generated one.

Closes #7