### PR TITLE
docs: update blog series links to canonical oldschool-engineer.dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,9 +108,9 @@ Additional Resources
 
 📖 **Blog Series:**
 
-- `Part 1: Why I Built It <https://the.oldschool.engineer/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-28fc3b6d9be0>`_
-- `Part 2: How to Run It <https://the.oldschool.engineer/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-part-2-94e445914951>`_
-- `Part 3: How to Deploy It <https://the.oldschool.engineer/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-part-3-eab7d9bbf5f7>`_
-- `Part 4: Evolution from Prototype to Production <https://the.oldschool.engineer/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-part-4-408779a1f3f2>`_
-- `Part 5: Wave 1 Complete: Bugs, Bottlenecks, and Breaking 1,000 msg/s <https://the.oldschool.engineer/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-part-5-5b1360b64921>`_
+- `Part 1: Why I Built It <https://oldschool-engineer.dev/side%20projects/2026/01/16/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner.html>`_
+- `Part 2: How to Run It <https://oldschool-engineer.dev/side%20projects/2026/01/21/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-part-2.html>`_
+- `Part 3: How to Deploy It <https://oldschool-engineer.dev/infrastructure/2026/01/31/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-part-3.html>`_
+- `Part 4: Evolution from Prototype to Production <https://oldschool-engineer.dev/software%20engineering/2026/02/11/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-part-4.html>`_
+- `Part 5: Wave 1 Complete: Bugs, Bottlenecks, and Breaking 1,000 msg/s <https://oldschool-engineer.dev/software%20engineering/2026/02/23/what-i-built-after-quitting-amazon-spoiler-its-a-stock-scanner-part-5.html>`_
 


### PR DESCRIPTION
## Summary

Update all blog series links from Medium (`the.oldschool.engineer`) to the canonical source at **oldschool-engineer.dev**.

Background: [Welcome to oldschool-engineer.dev](https://the.oldschool.engineer/welcome-to-oldschool-engineer-dev-fda484b66b02) — oldschool-engineer.dev is now the primary publishing location. The Medium posts remain but the owned domain is canonical.

## Changes

Replaced 5 Medium links with canonical oldschool-engineer.dev URLs:

- Part 1: Why I Built It
- Part 2: How to Run It
- Part 3: How to Deploy It
- Part 4: Evolution from Prototype to Production
- Part 5: Bugs, Bottlenecks, and Breaking 1,000 msg/s

## Why

- No paywall — any reader can access the content
- SEO accrues to the owned domain
- Consistent canonical source across GitHub and Read the Docs

Closes #10