### PR TITLE
ci: bump Docker GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for tags
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Install build dependencies
         run: pip install -r requirements-build.txt
@@ -66,7 +66,7 @@ jobs:
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -74,7 +74,7 @@ jobs:
 
       # MDL images
       - name: Build and push MDL Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./mdl.Dockerfile
@@ -86,7 +86,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push MDL (OTel auto-instrumented) Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./mdl_otel.Dockerfile
@@ -100,7 +100,7 @@ jobs:
 
       # MDP images
       - name: Build and push MDP Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./mdp.Dockerfile
@@ -112,7 +112,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push MDP (OTel auto-instrumented) Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./mdp_otel.Dockerfile
@@ -126,7 +126,7 @@ jobs:
 
       # LBA images
       - name: Build and push LBA Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./lba.Dockerfile
@@ -138,7 +138,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push LBA (OTel auto-instrumented) Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./lba_otel.Dockerfile
@@ -152,7 +152,7 @@ jobs:
 
       # WDS images
       - name: Build and push WDS Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./wds.Dockerfile
@@ -164,7 +164,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push WDS (OTel auto-instrumented) Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./wds_otel.Dockerfile
@@ -178,7 +178,7 @@ jobs:
 
       # Server Base image
       - name: Build and push MDP Server Base Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./base.Dockerfile


### PR DESCRIPTION
## Summary

Bump Docker-related GitHub Actions to versions that support Node.js 24, ahead of the **June 2, 2026** forced migration.

## Changes

| Action | Old | New |
|--------|-----|-----|
| `docker/setup-buildx-action` | `@v3` | `@v4` |
| `docker/login-action` | `@v3` | `@v4` |
| `docker/build-push-action` | `@v5` | `@v6` |

## Reference

- [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

Closes #12