### PR TITLE
feat: FDP server (FinlightDataProcessor)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ Container image build repository for the Kuhl Haus Market Data Platform (MDP) da
 
 | Server | Acronym | Role |
 |---|---|---|
-| Finlight Data Listener | FDL | WebSocket client → Finlight news API; routes articles to RabbitMQ with minimal processing |
+| Finlight Data Listener | FDL | WebSocket client → Finlight news API; routes articles to RabbitMQ news queue |
+| Finlight Data Processor | FDP | Async RabbitMQ consumer for Finlight news articles; delegates to analyzers; writes to Redis |
 | Market Data Listener | MDL | WebSocket client → Massive.com; routes events to RabbitMQ with minimal processing |
 | Market Data Processor | MDP | Horizontally-scalable event processor; semaphore-based concurrency (500 tasks); delegates to pluggable analyzers; writes to Redis |
 | Leaderboard Analyzer | LBA | Redis pub/sub consumer; runs leaderboard and trade analyzers with sequential processing |
@@ -32,6 +33,7 @@ All servers emit OpenTelemetry traces/metrics and structured JSON logs.
 ```
 src/kuhl_haus/servers/
 ├── fdl_server.py         # Finlight Data Listener server entry point
+├── fdp_server.py         # Finlight Data Processor server entry point
 ├── lba_server.py         # Leaderboard Analyzer server entry point
 ├── mdl_server.py         # Market Data Listener server entry point
 ├── mdp_server.py         # Market Data Processor server entry point
@@ -41,6 +43,7 @@ src/kuhl_haus/servers/
 # Dockerfiles — one standard + one OTel-instrumented variant per server
 base.Dockerfile           # Shared base image
 fdl.Dockerfile / fdl_otel.Dockerfile
+fdp.Dockerfile / fdp_otel.Dockerfile
 mdl.Dockerfile / mdl_otel.Dockerfile
 mdp.Dockerfile / mdp_otel.Dockerfile
 lba.Dockerfile / lba_otel.Dockerfile

--- a/fdp.Dockerfile
+++ b/fdp.Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=python:3.14
+FROM ${BASE_IMAGE}
+WORKDIR /tmp
+
+COPY requirements.txt /tmp/
+
+# Install requirements
+RUN pip install --no-cache-dir -r requirements.txt && \
+    rm -f /tmp/requirements.txt
+
+WORKDIR /app
+
+COPY . /app/
+
+# Install in editable mode
+RUN pip install --no-cache-dir -e .
+
+EXPOSE 4202/tcp
+CMD ["uvicorn", "kuhl_haus.servers.fdp_server:app", "--host", "0.0.0.0", "--port", "4202"]

--- a/fdp_otel.Dockerfile
+++ b/fdp_otel.Dockerfile
@@ -1,0 +1,22 @@
+ARG BASE_IMAGE=python:3.14
+FROM ${BASE_IMAGE}
+WORKDIR /tmp
+
+COPY requirements.txt /tmp/
+
+# Install requirements
+RUN pip install --no-cache-dir -r requirements.txt && \
+    rm -f /tmp/requirements.txt
+
+RUN pip install opentelemetry-distro
+
+WORKDIR /app
+
+COPY . /app/
+
+# Install in editable mode
+RUN pip install --no-cache-dir -e .
+RUN opentelemetry-bootstrap -a install
+
+EXPOSE 4202/tcp
+CMD ["opentelemetry-instrument", "uvicorn", "kuhl_haus.servers.fdp_server:app", "--host", "0.0.0.0", "--port", "4202"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ testing = [
 
 [project.scripts]
 fdl_server = "kuhl_haus.servers.fdl_server:app"
+fdp_server = "kuhl_haus.servers.fdp_server:app"
 lba_server = "kuhl_haus.servers.lba_server:app"
 mdl_server = "kuhl_haus.servers.mdl_server:app"
 mdp_server = "kuhl_haus.servers.mdp_server:app"

--- a/src/kuhl_haus/servers/fdp_server.py
+++ b/src/kuhl_haus/servers/fdp_server.py
@@ -1,0 +1,123 @@
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+from typing import Union
+
+from fastapi import FastAPI, Response, status
+from fastapi.responses import RedirectResponse
+from pydantic_settings import BaseSettings
+
+from kuhl_haus.mdp.components.finlight_data_processor import FinlightDataProcessor
+from kuhl_haus.mdp.enum.finlight_data_queue import FinlightDataQueue
+from kuhl_haus.mdp.helpers.structured_logging import setup_logging
+
+
+class Settings(BaseSettings):
+    # RabbitMQ Settings
+    rabbitmq_url: str = os.environ.get("RABBITMQ_URL", "amqp://mdq:mdq@localhost:5672/")
+
+    # Redis Settings
+    redis_url: str = os.environ.get("REDIS_URL", "redis://mdc:mdc@localhost:6379/0")
+
+    # Processor settings
+    queue_name: str = os.environ.get("FDP_QUEUE_NAME", FinlightDataQueue.NEWS.value)
+    prefetch_count: int = os.environ.get("PREFETCH_COUNT", 100)
+    max_concurrency: int = os.environ.get("MAX_CONCURRENCY", 500)
+
+    # Server Settings
+    server_ip: str = os.environ.get("SERVER_IP", "0.0.0.0")
+    server_port: int = os.environ.get("SERVER_PORT", 4202)
+    log_level: str = os.environ.get("LOG_LEVEL", "INFO").upper()
+    container_image: str = os.environ.get("CONTAINER_IMAGE", "Unknown")
+    image_version: str = os.environ.get("IMAGE_VERSION", "Unknown")
+
+
+settings = Settings()
+
+setup_logging(settings.log_level)
+logger = logging.getLogger(__name__)
+
+# Global state
+finlight_data_processor: FinlightDataProcessor = None
+processor_task: asyncio.Task = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Startup and shutdown events"""
+    global finlight_data_processor, processor_task
+
+    logger.info("Starting Finlight Data Processor...")
+
+    finlight_data_processor = FinlightDataProcessor(
+        rabbitmq_url=settings.rabbitmq_url,
+        queue_name=settings.queue_name,
+        redis_url=settings.redis_url,
+        analyzer_class=None,
+        prefetch_count=settings.prefetch_count,
+        max_concurrent_tasks=settings.max_concurrency,
+    )
+
+    processor_task = asyncio.create_task(finlight_data_processor.start())
+    logger.info("Finlight Data Processor is running.")
+
+    yield
+
+    # Shutdown
+    logger.info("Shutting down Finlight Data Processor...")
+    await finlight_data_processor.stop()
+    if processor_task and not processor_task.done():
+        processor_task.cancel()
+    logger.info("Finlight Data Processor stopped.")
+
+
+app = FastAPI(
+    title="Finlight Data Processor",
+    description="Consumes Finlight news articles from RabbitMQ and processes them through pluggable analyzers.",
+    lifespan=lifespan,
+)
+
+
+@app.get("/")
+async def root():
+    return RedirectResponse(url="/health")
+
+
+@app.get("/health", status_code=200)
+async def health_check(response: Response):
+    """Health check endpoint"""
+    try:
+        return {
+            "service": "Finlight Data Processor",
+            "status": "OK",
+            "status_code": 1,
+            "container_image": settings.container_image,
+            "image_version": settings.image_version,
+            "queue_name": settings.queue_name,
+            "prefetch_count": settings.prefetch_count,
+            "max_concurrency": settings.max_concurrency,
+            "processed": finlight_data_processor.processed,
+            "published": finlight_data_processor.published,
+            "error": finlight_data_processor.error,
+            "processing_error": finlight_data_processor.processing_error,
+            "decoding_error": finlight_data_processor.decoding_error,
+            "mdq_connected": finlight_data_processor.mdq_connected,
+            "mdc_connected": finlight_data_processor.mdc_connected,
+        }
+    except Exception as e:
+        logger.error(f"Health check error: {e}")
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {
+            "service": "Finlight Data Processor",
+            "status": "ERROR",
+            "status_code": 0,
+            "container_image": settings.container_image,
+            "image_version": settings.image_version,
+            "message": "An unhandled exception occurred during health check.",
+        }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=4202)

--- a/tests/servers/test_fdp_server.py
+++ b/tests/servers/test_fdp_server.py
@@ -1,0 +1,245 @@
+"""Unit tests for kuhl_haus.servers.fdp_server.
+
+TDD red phase — fdp_server.py does not yet exist. These tests define the
+expected contract and will fail at collection (ImportError) until the
+implementation is added.
+
+Run:
+    pytest tests/servers/test_fdp_server.py -v
+"""
+import asyncio
+import pytest
+from asgi_lifespan import LifespanManager
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import AsyncClient, ASGITransport
+
+MODULE = "kuhl_haus.servers.fdp_server"
+
+from kuhl_haus.servers.fdp_server import app, settings  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_processor():
+    mock = AsyncMock()
+    mock.processed = 0
+    mock.published = 0
+    mock.error = 0
+    mock.processing_error = 0
+    mock.decoding_error = 0
+    mock.mdq_connected = True
+    mock.mdc_connected = True
+    mock.start = AsyncMock()
+    mock.stop = AsyncMock()
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def client():
+    """AsyncClient with mocked FDP processor."""
+    mock_processor = _make_mock_processor()
+
+    with patch(f"{MODULE}.FinlightDataProcessor", return_value=mock_processor):
+        async with LifespanManager(app):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as ac:
+                yield ac, mock_processor
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+def test_fdp_settings_with_default_rabbitmq_url_expect_local_amqp():
+    assert settings.rabbitmq_url == "amqp://mdq:mdq@localhost:5672/"
+
+
+def test_fdp_settings_with_default_redis_url_expect_local_redis():
+    assert settings.redis_url == "redis://mdc:mdc@localhost:6379/0"
+
+
+def test_fdp_settings_with_default_server_port_expect_4202():
+    assert settings.server_port == 4202
+
+
+def test_fdp_settings_with_default_log_level_expect_info():
+    assert settings.log_level == "INFO"
+
+
+def test_fdp_settings_with_default_prefetch_count():
+    assert settings.prefetch_count == 100
+
+
+def test_fdp_settings_with_default_max_concurrency():
+    assert settings.max_concurrency == 500
+
+
+def test_fdp_settings_with_default_queue_name_expect_news():
+    assert settings.queue_name == "news"
+
+
+# ---------------------------------------------------------------------------
+# Lifespan — startup
+# ---------------------------------------------------------------------------
+
+async def test_fdp_lifespan_with_default_settings_expect_processor_started():
+    # Arrange
+    mock_processor = _make_mock_processor()
+
+    with patch(f"{MODULE}.FinlightDataProcessor", return_value=mock_processor) as mock_cls:
+        # Act
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    # Assert — processor instantiated and started
+    mock_cls.assert_called_once()
+    mock_processor.start.assert_awaited_once()
+
+
+async def test_fdp_lifespan_with_default_settings_expect_queue_name_passed():
+    # Arrange
+    mock_processor = _make_mock_processor()
+
+    with patch(f"{MODULE}.FinlightDataProcessor", return_value=mock_processor) as mock_cls:
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    # Assert — correct queue name passed to processor
+    call_kwargs = mock_cls.call_args.kwargs
+    assert call_kwargs["queue_name"] == settings.queue_name
+
+
+async def test_fdp_lifespan_with_default_settings_expect_no_massive_api_key():
+    # Arrange
+    mock_processor = _make_mock_processor()
+
+    with patch(f"{MODULE}.FinlightDataProcessor", return_value=mock_processor) as mock_cls:
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    # Assert — FinlightDataProcessor does not receive massive_api_key
+    call_kwargs = mock_cls.call_args.kwargs
+    assert "massive_api_key" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Lifespan — shutdown
+# ---------------------------------------------------------------------------
+
+async def test_fdp_lifespan_shutdown_expect_processor_stopped():
+    # Arrange
+    mock_processor = _make_mock_processor()
+
+    with patch(f"{MODULE}.FinlightDataProcessor", return_value=mock_processor):
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    # Assert — processor stopped on shutdown
+    mock_processor.stop.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+async def test_fdp_health_with_processor_running_expect_200(client):
+    # Arrange
+    ac, _ = client
+
+    # Act
+    response = await ac.get("/health")
+
+    # Assert
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "OK"
+    assert body["status_code"] == 1
+
+
+async def test_fdp_health_expect_service_name_finlight_data_processor(client):
+    # Arrange
+    ac, _ = client
+
+    # Act
+    response = await ac.get("/health")
+
+    # Assert
+    assert response.json()["service"] == "Finlight Data Processor"
+
+
+async def test_fdp_health_expect_processor_stats_in_response(client):
+    # Arrange
+    ac, mock_processor = client
+    mock_processor.processed = 42
+    mock_processor.published = 38
+    mock_processor.error = 1
+
+    # Act
+    response = await ac.get("/health")
+
+    # Assert
+    body = response.json()
+    assert "processed" in body
+    assert "published" in body
+    assert "error" in body
+
+
+async def test_fdp_health_expect_container_image_and_version(client):
+    # Arrange
+    ac, _ = client
+
+    # Act
+    response = await ac.get("/health")
+
+    # Assert
+    body = response.json()
+    assert "container_image" in body
+    assert "image_version" in body
+
+
+# ---------------------------------------------------------------------------
+# GET /
+# ---------------------------------------------------------------------------
+
+async def test_fdp_root_expect_redirect_to_health(client):
+    # Arrange
+    ac, _ = client
+
+    # Act
+    response = await ac.get("/", follow_redirects=False)
+
+    # Assert
+    assert response.status_code in (301, 302, 307, 308)
+    assert "/health" in response.headers.get("location", "")
+
+
+# ---------------------------------------------------------------------------
+# Parameterized settings
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("attr", [
+    "rabbitmq_url",
+    "redis_url",
+    "prefetch_count",
+    "max_concurrency",
+    "queue_name",
+    "log_level",
+    "server_port",
+    "container_image",
+    "image_version",
+])
+def test_fdp_settings_with_attr_expect_exists(attr):
+    # Arrange / Act / Assert
+    assert hasattr(settings, attr)


### PR DESCRIPTION
Closes #16

## Summary

Adds the FDP server — a FastAPI entry point wrapping `FinlightDataProcessor`, mirroring the MDP server pattern.

## TDD process (both commits in one push — same session)

- **Commit 1** (`065f411`): 25 unit tests
- **Commit 2** (`9bc03c2`): Implementation — 25 tests, all passing

## What's in this PR

- `src/kuhl_haus/servers/fdp_server.py` — FastAPI app, single async `FinlightDataProcessor` consuming from `news` queue
- `fdp.Dockerfile` / `fdp_otel.Dockerfile`
- `fdp_server` entry point in `pyproject.toml`
- FDP rows added to CLAUDE.md (servers table + code org + Dockerfiles)

## Key design decisions

- Single processor (no `ProcessManager` parallelism) — news feed, not high-throughput tick stream
- No `massive_api_key` — `FinlightDataProcessor` doesn't take one
- Port 4202 (MDL=4200, MDP=4201, FDL=4200, FDP=4202)
- `analyzer_class=None` placeholder until a Finlight-specific analyzer is built