### PR TITLE
fix: update default ports for FDL (4203) and FDP (4204)

### DIFF
--- a/fdl.Dockerfile
+++ b/fdl.Dockerfile
@@ -15,5 +15,5 @@ COPY . /app/
 # Install in editable mode
 RUN pip install --no-cache-dir -e .
 
-EXPOSE 4200/tcp
-CMD ["uvicorn", "kuhl_haus.servers.fdl_server:app", "--host", "0.0.0.0", "--port", "4200"]
+EXPOSE 4203/tcp
+CMD ["uvicorn", "kuhl_haus.servers.fdl_server:app", "--host", "0.0.0.0", "--port", "4203"]

--- a/fdl_otel.Dockerfile
+++ b/fdl_otel.Dockerfile
@@ -18,5 +18,5 @@ COPY . /app/
 RUN pip install --no-cache-dir -e .
 RUN opentelemetry-bootstrap -a install
 
-EXPOSE 4200/tcp
-CMD ["opentelemetry-instrument", "uvicorn", "kuhl_haus.servers.fdl_server:app", "--host", "0.0.0.0", "--port", "4200"]
+EXPOSE 4203/tcp
+CMD ["opentelemetry-instrument", "uvicorn", "kuhl_haus.servers.fdl_server:app", "--host", "0.0.0.0", "--port", "4203"]

--- a/fdp.Dockerfile
+++ b/fdp.Dockerfile
@@ -15,5 +15,5 @@ COPY . /app/
 # Install in editable mode
 RUN pip install --no-cache-dir -e .
 
-EXPOSE 4202/tcp
-CMD ["uvicorn", "kuhl_haus.servers.fdp_server:app", "--host", "0.0.0.0", "--port", "4202"]
+EXPOSE 4204/tcp
+CMD ["uvicorn", "kuhl_haus.servers.fdp_server:app", "--host", "0.0.0.0", "--port", "4204"]

--- a/fdp_otel.Dockerfile
+++ b/fdp_otel.Dockerfile
@@ -18,5 +18,5 @@ COPY . /app/
 RUN pip install --no-cache-dir -e .
 RUN opentelemetry-bootstrap -a install
 
-EXPOSE 4202/tcp
-CMD ["opentelemetry-instrument", "uvicorn", "kuhl_haus.servers.fdp_server:app", "--host", "0.0.0.0", "--port", "4202"]
+EXPOSE 4204/tcp
+CMD ["opentelemetry-instrument", "uvicorn", "kuhl_haus.servers.fdp_server:app", "--host", "0.0.0.0", "--port", "4204"]

--- a/src/kuhl_haus/servers/fdl_server.py
+++ b/src/kuhl_haus/servers/fdl_server.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
 
     # Server Settings
     server_ip: str = os.environ.get("SERVER_IP", "0.0.0.0")
-    server_port: int = os.environ.get("SERVER_PORT", 4200)
+    server_port: int = os.environ.get("SERVER_PORT", 4203)
     log_level: str = os.environ.get("LOG_LEVEL", "INFO").upper()
     container_image: str = os.environ.get("CONTAINER_IMAGE", "Unknown")
     image_version: str = os.environ.get("IMAGE_VERSION", "Unknown")
@@ -231,4 +231,4 @@ async def health_check(response: Response):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=4200)
+    uvicorn.run(app, host="0.0.0.0", port=4203)

--- a/src/kuhl_haus/servers/fdp_server.py
+++ b/src/kuhl_haus/servers/fdp_server.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
 
     # Server Settings
     server_ip: str = os.environ.get("SERVER_IP", "0.0.0.0")
-    server_port: int = os.environ.get("SERVER_PORT", 4202)
+    server_port: int = os.environ.get("SERVER_PORT", 4204)
     log_level: str = os.environ.get("LOG_LEVEL", "INFO").upper()
     container_image: str = os.environ.get("CONTAINER_IMAGE", "Unknown")
     image_version: str = os.environ.get("IMAGE_VERSION", "Unknown")
@@ -120,4 +120,4 @@ async def health_check(response: Response):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=4202)
+    uvicorn.run(app, host="0.0.0.0", port=4204)

--- a/tests/servers/test_fdp_server.py
+++ b/tests/servers/test_fdp_server.py
@@ -66,8 +66,8 @@ def test_fdp_settings_with_default_redis_url_expect_local_redis():
     assert settings.redis_url == "redis://mdc:mdc@localhost:6379/0"
 
 
-def test_fdp_settings_with_default_server_port_expect_4202():
-    assert settings.server_port == 4202
+def test_fdp_settings_with_default_server_port_expect_4204():
+    assert settings.server_port == 4204
 
 
 def test_fdp_settings_with_default_log_level_expect_info():


### PR DESCRIPTION
Corrects default port assignments so all servers can run on a single host via docker-compose without conflicts.

| Server | Port |
|---|---|
| SCP | 8000 |
| MDL | 4200 |
| MDP | 4201 |
| WDS | 4202 |
| FDL | **4203** (was 4200) |
| FDP | **4204** (was 4202) |
| LBA | 4210 |

Changes: `fdl_server.py`, `fdp_server.py`, `fdl.Dockerfile`, `fdl_otel.Dockerfile`, `fdp.Dockerfile`, `fdp_otel.Dockerfile`, FDP test default port assertion. All 59 tests passing.

Co-Authored-By: Tom Pounders <git@oldschool.engineer>