### PR TITLE
ci: add test and Codecov coverage step to build-images workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,6 +9,7 @@ on:
       - mainline
     tags:
       - 'v*'
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -50,6 +51,7 @@ jobs:
   build-docker:
     name: Build Docker Image
     needs: build-and-test
+    if: github.event_name != 'pull_request'  # skip Docker build on PRs
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -12,8 +12,44 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-and-test:
+    name: Build and Test Package
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history for tags
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.14"
+    - name: Install build dependencies
+      run: pip install -r requirements-build.txt
+    - name: Install package with test dependencies
+      run: pip install --no-cache-dir -e ".[testing]"
+
+    # Tests
+    - name: Run tests with coverage
+      run: pytest --cov=kuhl_haus.servers --cov-report=html --cov-report=xml tests -v
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: htmlcov/
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      if: startsWith(github.ref, 'refs/tags/')  # only upload on tag pushes
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: kuhl-haus/kuhl-haus-mdp-servers
+        fail_ci_if_error: true
+
   build-docker:
     name: Build Docker Image
+    needs: build-and-test
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Adds a `build-and-test` job before `build-docker`, following the same pattern as `kuhl-haus-mdp`'s `publish-to-pypi.yml`:

- Installs package with `.[testing]` extras
- Runs `pytest --cov=kuhl_haus.servers --cov-report=xml`
- Uploads HTML coverage as artifact on every run
- Uploads to Codecov on tag pushes only (`startsWith(github.ref, 'refs/tags/')`)
- `build-docker` now depends on `build-and-test`

Co-Authored-By: Tom Pounders <git@oldschool.engineer>