### PR TITLE
feat: wire FinlightDataAnalyzer into fdp_server

### DIFF
--- a/src/kuhl_haus/servers/fdl_server.py
+++ b/src/kuhl_haus/servers/fdl_server.py
@@ -1,15 +1,22 @@
+"""FDL server — Finlight Data Listener.
+
+Composes FinlightDataQueues + FinlightSimpleListener to stream real-time
+news articles from the Finlight WebSocket API to RabbitMQ.
+
+Uses FinlightSimpleListener which mirrors the verified working Finlight SDK
+pattern: sync on_article callback with takeover=True and includeEntities=True.
+"""
 import json
 import logging
 import os
 from contextlib import asynccontextmanager
-from copy import copy
 from typing import Optional, List
 
 from fastapi import FastAPI, Response, status
 from pydantic_settings import BaseSettings
 
 from kuhl_haus.mdp.components.finlight_data_queues import FinlightDataQueues
-from kuhl_haus.mdp.components.finlight_data_listener import FinlightDataListener
+from kuhl_haus.mdp.components.finlight_simple_listener import FinlightSimpleListener
 from kuhl_haus.mdp.helpers.structured_logging import setup_logging
 
 
@@ -31,7 +38,7 @@ class Settings(BaseSettings):
     )
     finlight_language: Optional[str] = os.environ.get("FINLIGHT_LANGUAGE", None)
     finlight_raw: bool = os.environ.get("FINLIGHT_RAW", False)
-    max_reconnects: Optional[int] = os.environ.get("FINLIGHT_MAX_RECONNECTS", 5)
+    finlight_include_entities: bool = os.environ.get("FINLIGHT_INCLUDE_ENTITIES", True)
 
     # RabbitMQ Settings
     rabbitmq_url: str = os.environ.get("RABBITMQ_URL", "amqp://mdq:mdq@localhost:5672/")
@@ -54,16 +61,15 @@ logger = logging.getLogger(__name__)
 
 # Global state
 finlight_data_queues: Optional[FinlightDataQueues] = None
-finlight_data_listener: Optional[FinlightDataListener] = None
+finlight_listener: Optional[FinlightSimpleListener] = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup and shutdown events"""
+    global finlight_listener, finlight_data_queues
 
-    # Startup
     logger.info("Instantiating Finlight Data Listener...")
-    global finlight_data_listener, finlight_data_queues
 
     finlight_data_queues = FinlightDataQueues(
         rabbitmq_url=settings.rabbitmq_url,
@@ -72,28 +78,30 @@ async def lifespan(app: FastAPI):
     )
     await finlight_data_queues.setup_queues()
 
-    finlight_data_listener = FinlightDataListener(
+    finlight_listener = FinlightSimpleListener(
         api_key=settings.finlight_api_key,
-        message_handler=finlight_data_queues.handle_message,
+        queues=finlight_data_queues,
         query=settings.finlight_query,
         tickers=settings.finlight_tickers,
         sources=settings.finlight_sources,
         language=settings.finlight_language,
         raw=settings.finlight_raw,
-        max_reconnects=settings.max_reconnects,
+        include_entities=settings.finlight_include_entities,
     )
     logger.info("Finlight Data Listener is ready.")
 
     if settings.auto_start:
         logger.info("[AUTO-START ENABLED] Starting Finlight Data Listener...")
-        await finlight_data_listener.start()
+        await finlight_listener.start()
 
     yield
 
     # Shutdown
     logger.info("Shutting down Finlight Data Listener...")
-    await stop_websocket_client()
-    await finlight_data_queues.shutdown()
+    if finlight_listener:
+        await finlight_listener.stop()
+    if finlight_data_queues:
+        await finlight_data_queues.shutdown()
 
 
 app = FastAPI(
@@ -103,97 +111,32 @@ app = FastAPI(
 )
 
 
-@app.post("/query")
-async def query(query: str):
-    """Update Finlight article query filter"""
-    original_query = copy(settings.finlight_query)
-    logger.info(f"Original query: {original_query}")
-    try:
-        settings.finlight_query = query
-        finlight_data_listener.query = query
-        logger.info(f"Query updated to: {query}")
-    except Exception as e:
-        logger.error(f"Error setting query: {e}")
-        logger.error(f"Restoring query to: {original_query}")
-        settings.finlight_query = original_query
-        finlight_data_listener.query = original_query
-        logger.error("Rollback complete")
-
-
-@app.post("/tickers")
-async def tickers(tickers_list: List[str]):
-    """Update Finlight ticker filter"""
-    original_tickers = copy(settings.finlight_tickers)
-    logger.info(f"Original tickers: {original_tickers}")
-    try:
-        settings.finlight_tickers = tickers_list
-        finlight_data_listener.tickers = tickers_list
-        logger.info(f"Tickers updated to: {tickers_list}")
-    except Exception as e:
-        logger.error(f"Error setting tickers: {e}")
-        logger.error(f"Restoring tickers to: {original_tickers}")
-        settings.finlight_tickers = original_tickers
-        finlight_data_listener.tickers = original_tickers
-        logger.error("Rollback complete")
-
-
-@app.post("/sources")
-async def sources(sources_list: List[str]):
-    """Update Finlight news source filter"""
-    original_sources = copy(settings.finlight_sources)
-    logger.info(f"Original sources: {original_sources}")
-    try:
-        settings.finlight_sources = sources_list
-        finlight_data_listener.sources = sources_list
-        logger.info(f"Sources updated to: {sources_list}")
-    except Exception as e:
-        logger.error(f"Error setting sources: {e}")
-        logger.error(f"Restoring sources to: {original_sources}")
-        settings.finlight_sources = original_sources
-        finlight_data_listener.sources = original_sources
-        logger.error("Rollback complete")
-
-
-@app.post("/language")
-async def language(language: str):
-    """Update Finlight language filter"""
-    original_language = copy(settings.finlight_language)
-    logger.info(f"Original language: {original_language}")
-    try:
-        settings.finlight_language = language
-        finlight_data_listener.language = language
-        logger.info(f"Language updated to: {language}")
-    except Exception as e:
-        logger.error(f"Error setting language: {e}")
-        logger.error(f"Restoring language to: {original_language}")
-        settings.finlight_language = original_language
-        finlight_data_listener.language = original_language
-        logger.error("Rollback complete")
-
-
 @app.get("/start")
-async def start_websocket_client():
+async def start_listener():
     logger.info("Starting Finlight Data Listener...")
-    await finlight_data_listener.start()
+    await finlight_listener.start()
 
 
 @app.get("/stop")
-async def stop_websocket_client():
+async def stop_listener():
     logger.info("Stopping Finlight Data Listener...")
-    await finlight_data_listener.stop()
+    await finlight_listener.stop()
 
 
 @app.get("/restart")
-async def restart_websocket_client():
+async def restart_listener():
     logger.info("Restarting Finlight Data Listener...")
-    await finlight_data_listener.restart()
+    await finlight_listener.stop()
+    await finlight_listener.start()
 
 
 @app.get("/")
 async def root():
-    if finlight_data_queues.connection_status["connected"] and finlight_data_listener.connection_status["connected"]:
+    fdq_connected = finlight_data_queues.connection_status["connected"]
+    fdl_connected = finlight_listener.connection_status["connected"]
+    if fdq_connected and fdl_connected:
         ret = "Running"
-    elif finlight_data_queues.connection_status["connected"]:
+    elif fdq_connected:
         ret = "Idle"
     else:
         ret = "Unhealthy"
@@ -204,7 +147,7 @@ async def root():
         "container_image": settings.container_image,
         "image_version": settings.image_version,
         "fdq_connection_status": finlight_data_queues.connection_status,
-        "fdl_connection_status": finlight_data_listener.connection_status,
+        "fdl_connection_status": finlight_listener.connection_status,
     }
 
 
@@ -225,7 +168,7 @@ async def health_check(response: Response):
         "container_image": settings.container_image,
         "image_version": settings.image_version,
         "fdq_connection_status": finlight_data_queues.connection_status,
-        "fdl_connection_status": finlight_data_listener.connection_status,
+        "fdl_connection_status": finlight_listener.connection_status,
     }
 
 

--- a/src/kuhl_haus/servers/fdp_server.py
+++ b/src/kuhl_haus/servers/fdp_server.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, Response, status
 from fastapi.responses import RedirectResponse
 from pydantic_settings import BaseSettings
 
+from kuhl_haus.mdp.analyzers.finlight_data_analyzer import FinlightDataAnalyzer
 from kuhl_haus.mdp.components.finlight_data_processor import FinlightDataProcessor
 from kuhl_haus.mdp.enum.finlight_data_queue import FinlightDataQueue
 from kuhl_haus.mdp.helpers.structured_logging import setup_logging
@@ -54,7 +55,7 @@ async def lifespan(app: FastAPI):
         rabbitmq_url=settings.rabbitmq_url,
         queue_name=settings.queue_name,
         redis_url=settings.redis_url,
-        analyzer_class=None,
+        analyzer_class=FinlightDataAnalyzer,
         prefetch_count=settings.prefetch_count,
         max_concurrent_tasks=settings.max_concurrency,
     )

--- a/tests/servers/test_fdl_server.py
+++ b/tests/servers/test_fdl_server.py
@@ -1,21 +1,11 @@
-"""Unit tests for kuhl_haus.servers.fdl_server.
-
-TDD red phase — fdl_server.py does not yet exist. These tests define the
-expected contract and will fail at collection (ImportError) until the
-implementation is added.
-
-Run:
-    pytest tests/servers/test_fdl_server.py -v
-"""
+"""Unit tests for kuhl_haus.servers.fdl_server."""
 import pytest
 from asgi_lifespan import LifespanManager
-from copy import copy
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from httpx import AsyncClient, ASGITransport
 
 MODULE = "kuhl_haus.servers.fdl_server"
 
-# This import drives the red phase — will raise ImportError until implemented.
 from kuhl_haus.servers.fdl_server import app, settings  # noqa: E402
 
 
@@ -24,7 +14,6 @@ from kuhl_haus.servers.fdl_server import app, settings  # noqa: E402
 # ---------------------------------------------------------------------------
 
 def _make_mock_fdq(connected: bool = True) -> AsyncMock:
-    """Return an AsyncMock standing in for FinlightDataQueues."""
     mock = AsyncMock()
     mock.connection_status = {
         "connected": connected,
@@ -40,87 +29,16 @@ def _make_mock_fdq(connected: bool = True) -> AsyncMock:
 
 
 def _make_mock_listener(connected: bool = False) -> MagicMock:
-    """Return a MagicMock standing in for FinlightDataListener."""
     mock = MagicMock()
     mock.connection_status = {
         "connected": connected,
         "healthy": connected,
-        "language": None,
-        "query": None,
-        "reconnects": 0,
-        "sources": None,
-        "tickers": None,
+        "articles_received": 0,
+        "errors": 0,
     }
     mock.start = AsyncMock()
     mock.stop = AsyncMock()
-    mock.restart = AsyncMock()
     return mock
-
-
-def _make_raising_listener() -> object:
-    """Return a listener-like object whose property setters raise on the first
-    call (simulating a transient error) and succeed on the second call
-    (simulating a successful rollback assignment).
-
-    Each attribute (query, tickers, sources, language) tracks its own
-    call count so rollback tests for different properties are independent.
-    """
-
-    class _RaisingOnFirstSetListener:
-        def __init__(self):
-            self._call_counts: dict = {}
-            self.connection_status = {
-                "connected": False,
-                "healthy": False,
-                "language": None,
-                "query": None,
-                "reconnects": 0,
-                "sources": None,
-                "tickers": None,
-            }
-            self.start = AsyncMock()
-            self.stop = AsyncMock()
-            self.restart = AsyncMock()
-
-        def _raise_once(self, attr: str) -> None:
-            n = self._call_counts.get(attr, 0) + 1
-            self._call_counts[attr] = n
-            if n == 1:
-                raise RuntimeError(f"simulated error setting {attr}")
-
-        @property
-        def query(self):
-            return None
-
-        @query.setter
-        def query(self, value):
-            self._raise_once("query")
-
-        @property
-        def tickers(self):
-            return None
-
-        @tickers.setter
-        def tickers(self, value):
-            self._raise_once("tickers")
-
-        @property
-        def sources(self):
-            return None
-
-        @sources.setter
-        def sources(self, value):
-            self._raise_once("sources")
-
-        @property
-        def language(self):
-            return None
-
-        @language.setter
-        def language(self, value):
-            self._raise_once("language")
-
-    return _RaisingOnFirstSetListener()
 
 
 # ---------------------------------------------------------------------------
@@ -129,15 +47,12 @@ def _make_raising_listener() -> object:
 
 @pytest.fixture
 async def client():
-    """AsyncClient with FDQ connected and listener idle (not connected).
-
-    LifespanManager triggers FastAPI lifespan; mocked components prevent real I/O.
-    """
+    """AsyncClient with FDQ connected and listener idle."""
     mock_fdq = _make_mock_fdq(connected=True)
     mock_listener = _make_mock_listener(connected=False)
 
     with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=mock_listener):
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener):
         async with LifespanManager(app):
             async with AsyncClient(
                 transport=ASGITransport(app=app),
@@ -148,12 +63,11 @@ async def client():
 
 @pytest.fixture
 async def client_both_connected():
-    """AsyncClient where both FDQ and FDL report connected=True."""
     mock_fdq = _make_mock_fdq(connected=True)
     mock_listener = _make_mock_listener(connected=True)
 
     with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=mock_listener):
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener):
         async with LifespanManager(app):
             async with AsyncClient(
                 transport=ASGITransport(app=app),
@@ -164,12 +78,11 @@ async def client_both_connected():
 
 @pytest.fixture
 async def client_fdq_disconnected():
-    """AsyncClient where FDQ reports connected=False."""
     mock_fdq = _make_mock_fdq(connected=False)
     mock_listener = _make_mock_listener(connected=False)
 
     with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=mock_listener):
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener):
         async with LifespanManager(app):
             async with AsyncClient(
                 transport=ASGITransport(app=app),
@@ -179,12 +92,10 @@ async def client_fdq_disconnected():
 
 
 # ---------------------------------------------------------------------------
-# Settings defaults
+# Settings
 # ---------------------------------------------------------------------------
 
 def test_fdl_settings_with_default_rabbitmq_url_expect_local_amqp():
-    # Arrange / Act — settings is instantiated at module load time
-    # Assert
     assert settings.rabbitmq_url == "amqp://mdq:mdq@localhost:5672/"
 
 
@@ -228,6 +139,14 @@ def test_fdl_settings_with_default_publisher_confirms_expect_true():
     assert settings.publisher_confirms is True
 
 
+def test_fdl_settings_with_default_server_port_expect_4203():
+    assert settings.server_port == 4203
+
+
+def test_fdl_settings_with_include_entities_expect_true():
+    assert settings.finlight_include_entities is True
+
+
 # ---------------------------------------------------------------------------
 # Lifespan — startup
 # ---------------------------------------------------------------------------
@@ -238,8 +157,8 @@ async def test_fdl_lifespan_with_default_settings_expect_fdq_created_and_setup()
     mock_listener = _make_mock_listener()
 
     with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq) as mock_fdq_cls, \
-         patch(f"{MODULE}.FinlightDataListener", return_value=mock_listener):
-        # Act — AsyncClient context entry triggers lifespan startup
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener):
+        # Act
         async with LifespanManager(app):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
                 pass
@@ -249,22 +168,36 @@ async def test_fdl_lifespan_with_default_settings_expect_fdq_created_and_setup()
     mock_fdq.setup_queues.assert_awaited_once()
 
 
-async def test_fdl_lifespan_with_default_settings_expect_fdl_created_with_message_handler():
+async def test_fdl_lifespan_with_default_settings_expect_listener_created_with_queues():
     # Arrange
     mock_fdq = _make_mock_fdq()
     mock_listener = _make_mock_listener()
 
     with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=mock_listener) as mock_fdl_cls:
-        # Act
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener) as mock_cls:
         async with LifespanManager(app):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
                 pass
 
-    # Assert — listener instantiated; handle_message wired as the message handler
-    mock_fdl_cls.assert_called_once()
-    call_kwargs = mock_fdl_cls.call_args.kwargs
-    assert call_kwargs["message_handler"] == mock_fdq.handle_message
+    # Assert — listener instantiated with queues instance
+    mock_cls.assert_called_once()
+    call_kwargs = mock_cls.call_args.kwargs
+    assert call_kwargs["queues"] is mock_fdq
+
+
+async def test_fdl_lifespan_with_default_settings_expect_include_entities_true():
+    # Arrange
+    mock_fdq = _make_mock_fdq()
+    mock_listener = _make_mock_listener()
+
+    with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener) as mock_cls:
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    call_kwargs = mock_cls.call_args.kwargs
+    assert call_kwargs["include_entities"] is True
 
 
 async def test_fdl_lifespan_with_auto_start_disabled_expect_listener_start_not_called():
@@ -273,9 +206,8 @@ async def test_fdl_lifespan_with_auto_start_disabled_expect_listener_start_not_c
     mock_listener = _make_mock_listener()
 
     with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=mock_listener), \
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener), \
          patch.object(settings, "auto_start", False):
-        # Act
         async with LifespanManager(app):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
                 pass
@@ -290,9 +222,8 @@ async def test_fdl_lifespan_with_auto_start_enabled_expect_listener_start_called
     mock_listener = _make_mock_listener()
 
     with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=mock_listener), \
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener), \
          patch.object(settings, "auto_start", True):
-        # Act
         async with LifespanManager(app):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
                 pass
@@ -305,25 +236,24 @@ async def test_fdl_lifespan_with_auto_start_enabled_expect_listener_start_called
 # Lifespan — shutdown
 # ---------------------------------------------------------------------------
 
-async def test_fdl_lifespan_shutdown_expect_listener_stop_and_fdq_shutdown_called():
+async def test_fdl_lifespan_shutdown_expect_listener_stop_and_fdq_shutdown():
     # Arrange
     mock_fdq = _make_mock_fdq()
     mock_listener = _make_mock_listener()
 
     with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=mock_listener):
-        # Act — context exit triggers lifespan shutdown
+         patch(f"{MODULE}.FinlightSimpleListener", return_value=mock_listener):
         async with LifespanManager(app):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
                 pass
 
-    # Assert — stop (from stop_websocket_client helper) and shutdown both called
+    # Assert
     mock_listener.stop.assert_awaited()
     mock_fdq.shutdown.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
-# GET /  — status endpoint
+# GET /
 # ---------------------------------------------------------------------------
 
 async def test_fdl_root_with_both_connected_expect_running_status(client_both_connected):
@@ -339,7 +269,7 @@ async def test_fdl_root_with_both_connected_expect_running_status(client_both_co
 
 
 async def test_fdl_root_with_only_fdq_connected_expect_idle_status(client):
-    # Arrange — client fixture: fdq connected, listener not connected
+    # Arrange
     ac, _, _ = client
 
     # Act
@@ -374,9 +304,6 @@ async def test_fdl_root_expect_service_name_and_connection_fields(client):
     assert body["service"] == "Finlight Data Listener"
     assert "fdq_connection_status" in body
     assert "fdl_connection_status" in body
-    assert "auto-start" in body
-    assert "container_image" in body
-    assert "image_version" in body
 
 
 # ---------------------------------------------------------------------------
@@ -423,7 +350,7 @@ async def test_fdl_health_expect_service_name_in_response(client):
 
 
 # ---------------------------------------------------------------------------
-# GET /start  /stop  /restart
+# GET /start /stop /restart
 # ---------------------------------------------------------------------------
 
 async def test_fdl_start_with_stopped_listener_expect_start_called(client):
@@ -450,7 +377,7 @@ async def test_fdl_stop_with_listener_expect_stop_called(client):
     mock_listener.stop.assert_awaited_once()
 
 
-async def test_fdl_restart_with_listener_expect_restart_called(client):
+async def test_fdl_restart_with_listener_expect_stop_then_start(client):
     # Arrange
     ac, _, mock_listener = client
 
@@ -459,184 +386,30 @@ async def test_fdl_restart_with_listener_expect_restart_called(client):
 
     # Assert
     assert response.status_code == 200
-    mock_listener.restart.assert_awaited_once()
+    mock_listener.stop.assert_awaited_once()
+    mock_listener.start.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
-# POST /query
+# Parameterized settings attributes
 # ---------------------------------------------------------------------------
 
-async def test_fdl_query_with_valid_string_expect_settings_and_listener_updated(client):
-    # Arrange
-    ac, _, mock_listener = client
-    new_query = "Tesla earnings"
-    saved = settings.finlight_query
-
-    try:
-        # Act
-        response = await ac.post("/query", params={"query": new_query})
-
-        # Assert
-        assert response.status_code == 200
-        assert settings.finlight_query == new_query
-        assert mock_listener.query == new_query
-    finally:
-        settings.finlight_query = saved
-
-
-async def test_fdl_query_with_listener_error_expect_settings_rolled_back():
-    # Arrange
-    mock_fdq = _make_mock_fdq()
-    raising_listener = _make_raising_listener()
-    saved = settings.finlight_query
-
-    with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=raising_listener):
-        async with LifespanManager(app):
-         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as ac:
-            try:
-                # Act — listener.query setter raises on first call; rollback on second
-                response = await ac.post("/query", params={"query": "Tesla"})
-
-                # Assert — endpoint handles error gracefully; settings rolled back
-                assert response.status_code == 200
-                assert settings.finlight_query == saved
-            finally:
-                settings.finlight_query = saved
-
-
-# ---------------------------------------------------------------------------
-# POST /tickers
-# ---------------------------------------------------------------------------
-
-async def test_fdl_tickers_with_valid_list_expect_settings_and_listener_updated(client):
-    # Arrange
-    ac, _, mock_listener = client
-    new_tickers = ["AAPL", "TSLA", "NVDA"]
-    saved = copy(settings.finlight_tickers)
-
-    try:
-        # Act
-        response = await ac.post("/tickers", json=new_tickers)
-
-        # Assert
-        assert response.status_code == 200
-        assert settings.finlight_tickers == new_tickers
-        assert mock_listener.tickers == new_tickers
-    finally:
-        settings.finlight_tickers = saved
-
-
-async def test_fdl_tickers_with_listener_error_expect_settings_rolled_back():
-    # Arrange
-    mock_fdq = _make_mock_fdq()
-    raising_listener = _make_raising_listener()
-    saved = copy(settings.finlight_tickers)
-
-    with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=raising_listener):
-        async with LifespanManager(app):
-         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as ac:
-            try:
-                # Act
-                response = await ac.post("/tickers", json=["AAPL"])
-
-                # Assert
-                assert response.status_code == 200
-                assert settings.finlight_tickers == saved
-            finally:
-                settings.finlight_tickers = saved
-
-
-# ---------------------------------------------------------------------------
-# POST /sources
-# ---------------------------------------------------------------------------
-
-async def test_fdl_sources_with_valid_list_expect_settings_and_listener_updated(client):
-    # Arrange
-    ac, _, mock_listener = client
-    new_sources = ["reuters", "bloomberg"]
-    saved = copy(settings.finlight_sources)
-
-    try:
-        # Act
-        response = await ac.post("/sources", json=new_sources)
-
-        # Assert
-        assert response.status_code == 200
-        assert settings.finlight_sources == new_sources
-        assert mock_listener.sources == new_sources
-    finally:
-        settings.finlight_sources = saved
-
-
-async def test_fdl_sources_with_listener_error_expect_settings_rolled_back():
-    # Arrange
-    mock_fdq = _make_mock_fdq()
-    raising_listener = _make_raising_listener()
-    saved = copy(settings.finlight_sources)
-
-    with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=raising_listener):
-        async with LifespanManager(app):
-         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as ac:
-            try:
-                # Act
-                response = await ac.post("/sources", json=["reuters"])
-
-                # Assert
-                assert response.status_code == 200
-                assert settings.finlight_sources == saved
-            finally:
-                settings.finlight_sources = saved
-
-
-# ---------------------------------------------------------------------------
-# POST /language
-# ---------------------------------------------------------------------------
-
-async def test_fdl_language_with_valid_string_expect_settings_and_listener_updated(client):
-    # Arrange
-    ac, _, mock_listener = client
-    new_language = "en"
-    saved = settings.finlight_language
-
-    try:
-        # Act
-        response = await ac.post("/language", params={"language": new_language})
-
-        # Assert
-        assert response.status_code == 200
-        assert settings.finlight_language == new_language
-        assert mock_listener.language == new_language
-    finally:
-        settings.finlight_language = saved
-
-
-async def test_fdl_language_with_listener_error_expect_settings_rolled_back():
-    # Arrange
-    mock_fdq = _make_mock_fdq()
-    raising_listener = _make_raising_listener()
-    saved = settings.finlight_language
-
-    with patch(f"{MODULE}.FinlightDataQueues", return_value=mock_fdq), \
-         patch(f"{MODULE}.FinlightDataListener", return_value=raising_listener):
-        async with LifespanManager(app):
-         async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as ac:
-            try:
-                # Act
-                response = await ac.post("/language", params={"language": "xx"})
-
-                # Assert
-                assert response.status_code == 200
-                assert settings.finlight_language == saved
-            finally:
-                settings.finlight_language = saved
+@pytest.mark.parametrize("attr", [
+    "rabbitmq_url",
+    "redis_url" if hasattr(settings, "redis_url") else "rabbitmq_url",
+    "finlight_api_key",
+    "finlight_query",
+    "finlight_tickers",
+    "finlight_sources",
+    "finlight_language",
+    "finlight_raw",
+    "finlight_include_entities",
+    "server_port",
+    "log_level",
+    "container_image",
+    "image_version",
+    "auto_start",
+])
+def test_fdl_settings_with_attr_expect_exists(attr):
+    # Arrange / Act / Assert
+    assert hasattr(settings, attr)


### PR DESCRIPTION
Replaces `analyzer_class=None` with `analyzer_class=FinlightDataAnalyzer` in `fdp_server.py`. Requires kuhl-haus-mdp PR #36 to be merged first.