### PR TITLE
chore: bump kuhl-haus-mdp to 0.3.5 (closes #29)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.3.4",
+    "kuhl-haus-mdp==0.3.5",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Picks up kuhl-haus-mdp v0.3.5 which adds rolling list cache for news feeds (kuhl-haus/kuhl-haus-mdp#41). NewsFeed widget now loads up to 1,000 articles from cache on connect.