### PR TITLE
ci: add test step to build-package job in publish-to-pypi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -37,6 +37,10 @@ jobs:
     - name: Install package with build dependencies
       run: pip install --no-cache-dir -e ".[testing]"
 
+    # Tests
+    - name: Run tests with coverage
+      run: pytest --cov=kuhl_haus.servers --cov-report=html --cov-report=xml tests -v
+
     # Build Distribution Package
     - name: Build package
       run: pdm build


### PR DESCRIPTION
Adds `pytest --cov` step to `build-package` in `publish-to-pypi.yml`, matching the pattern already in `build-images.yml`. Tests now run before the package is built and published to PyPI.