### PR TITLE
chore: pin kuhl-haus-mdp to v0.3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.3.7",
+    "kuhl-haus-mdp==0.3.8",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Picks up kuhl-haus-mdp v0.3.8 which adds the per-symbol `quote:{symbol}` pub/sub feed via `LeaderboardAnalyzer` for the Quote widget (kuhl-haus-mdp-app PR #88).