### PR TITLE
chore: pin kuhl-haus-mdp to v0.3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.3.8",
+    "kuhl-haus-mdp==0.3.9",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Picks up kuhl-haus-mdp v0.3.9 which fixes two bugs in `widget_data_service._handle_pubsub()`:

- **RuntimeError: Set changed size during iteration** — fixed by iterating `list(self.subscriptions[feed])` snapshot
- **TypeError in logger.error()** — fixed with `exc_info=True`

Reported in #35.