### PR TITLE
chore: pin kuhl-haus-mdp to v0.3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.3.9",
+    "kuhl-haus-mdp==0.3.10",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Picks up kuhl-haus-mdp v0.3.10: fixes `quote:{symbol}` pub/sub publishing — now emitted on every agg event from every LBA instance instead of only on throttled leaderboard publish. Quote widget updates are now live (~1/sec per ticker).