### PR TITLE
chore: pin kuhl-haus-mdp to 0.3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.3.10",
+    "kuhl-haus-mdp==0.3.11",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Pins `kuhl-haus-mdp` to `0.3.11`, which adds `prev_day_open`, `prev_day_high`, and `prev_day_low` to the `LeaderboardAnalyzer` symbol metadata hash.

Required for the Quote widget to display a complete Previous Day section (kuhl-haus/kuhl-haus-mdp-app#97).

refs #42