### PR TITLE
chore: pin kuhl-haus-mdp to 0.3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.3.12",
+    "kuhl-haus-mdp==0.3.13",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Pins to [v0.3.13](https://pypi.org/project/kuhl-haus-mdp/0.3.13/).

Picks up: `perf(LeaderboardAnalyzer)` — eliminate redundant `hgetall` for quote publication (refs kuhl-haus/kuhl-haus-mdp#62).