### PR TITLE
feat: split REDIS_URL into MDC_REDIS_URL and WDC_REDIS_URL; pin mdp to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.3.15",
+    "kuhl-haus-mdp==0.4.0",
     "websockets",
     "aio-pika",
     "redis",

--- a/src/kuhl_haus/servers/fdp_server.py
+++ b/src/kuhl_haus/servers/fdp_server.py
@@ -21,7 +21,8 @@ class Settings(BaseSettings):
     rabbitmq_url: str = os.environ.get("RABBITMQ_URL", "amqp://mdq:mdq@localhost:5672/")
 
     # Redis Settings
-    redis_url: str = os.environ.get("REDIS_URL", "redis://mdc:mdc@localhost:6379/0")
+    mdc_redis_url: str = os.environ.get("MDC_REDIS_URL", "redis://mdc:mdc@localhost:6379/0")
+    wdc_redis_url: str = os.environ.get("WDC_REDIS_URL", "redis://mdc:mdc@localhost:6379/1")
 
     # Processor settings
     queue_name: str = os.environ.get("FDP_QUEUE_NAME", FinlightDataQueue.NEWS.value)
@@ -61,7 +62,7 @@ async def lifespan(app: FastAPI):
     logger.info("Starting Finlight Data Processor...")
 
     analyzer_options = AnalyzerOptions(
-        redis_url=settings.redis_url,
+        redis_url=settings.mdc_redis_url,
         finlight_api_key=settings.finlight_api_key or None,
         kwargs={
             "news_feed_list_max": settings.news_feed_list_max,
@@ -74,7 +75,7 @@ async def lifespan(app: FastAPI):
     finlight_data_processor = FinlightDataProcessor(
         rabbitmq_url=settings.rabbitmq_url,
         queue_name=settings.queue_name,
-        redis_url=settings.redis_url,
+        redis_url=settings.wdc_redis_url,
         analyzer_class=FinlightDataAnalyzer,
         analyzer_options=analyzer_options,
         prefetch_count=settings.prefetch_count,

--- a/src/kuhl_haus/servers/lba_server.py
+++ b/src/kuhl_haus/servers/lba_server.py
@@ -6,6 +6,7 @@ from typing import List, Union
 from fastapi import FastAPI, Response, status
 from fastapi.responses import RedirectResponse
 from kuhl_haus.mdp.analyzers.leaderboard_analyzer import LeaderboardAnalyzer
+from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
 from kuhl_haus.mdp.components.massive_data_processor import MassiveDataProcessor
 from kuhl_haus.mdp.enum.massive_data_queue import MassiveDataQueue
 from kuhl_haus.mdp.helpers.process_manager import ProcessManager
@@ -26,8 +27,9 @@ class Settings(BaseSettings):
     # RabbitMQ Settings - Market Data Queue
     rabbitmq_url: str = os.environ.get("RABBITMQ_URL", "amqp://mdq:mdq@localhost:5672/")
 
-    # Redis Settings - Market Data Cache
-    redis_url: str = os.environ.get("REDIS_URL", "redis://mdc:mdc@localhost:6379/0")
+    # Redis Settings
+    mdc_redis_url: str = os.environ.get("MDC_REDIS_URL", "redis://mdc:mdc@localhost:6379/0")
+    wdc_redis_url: str = os.environ.get("WDC_REDIS_URL", "redis://mdc:mdc@localhost:6379/1")
 
     # Server Settings
     server_ip: str = os.environ.get("SERVER_IP", "0.0.0.0")
@@ -63,14 +65,18 @@ async def lifespan(app: FastAPI):
     for i in range(settings.parallelism):
         name = f"lba_{MassiveDataQueue.AGGREGATE.value}_{i}"
         logger.info(f"Creating MassiveDataProcessor: {name}")
+        analyzer_options = AnalyzerOptions(
+            redis_url=settings.mdc_redis_url,
+            massive_api_key=settings.massive_api_key,
+        )
         process_manager.start_worker(
             name=name,
             worker_class=MassiveDataProcessor,
             rabbitmq_url=settings.rabbitmq_url,
             queue_name=MassiveDataQueue.AGGREGATE.value,
-            redis_url=settings.redis_url,
-            massive_api_key=settings.massive_api_key,
+            redis_url=settings.wdc_redis_url,
             analyzer_class=LeaderboardAnalyzer,
+            analyzer_options=analyzer_options,
             prefetch_count=settings.prefetch_count,
             max_concurrent_tasks=settings.max_concurrency,
         )

--- a/src/kuhl_haus/servers/mdl_server.py
+++ b/src/kuhl_haus/servers/mdl_server.py
@@ -35,8 +35,6 @@ class Settings(BaseSettings):
     max_reconnects: Optional[int] = os.environ.get("MASSIVE_MAX_RECONNECTS", 5)
     secure: bool = os.environ.get("MASSIVE_SECURE", True)
 
-    # Redis Settings
-    redis_url: str = os.environ.get("REDIS_URL", "redis://mdc:mdc@localhost:6379/0")
 
     # RabbitMQ Settings
     rabbitmq_url: str = os.environ.get("RABBITMQ_URL", "amqp://mdq:mdq@localhost:5672/")

--- a/src/kuhl_haus/servers/mdp_server.py
+++ b/src/kuhl_haus/servers/mdp_server.py
@@ -11,6 +11,7 @@ from kuhl_haus.mdp.analyzers.top_trades_analyzer import TopTradesAnalyzer
 from kuhl_haus.mdp.components.massive_data_processor import MassiveDataProcessor
 from kuhl_haus.mdp.enum.massive_data_queue import MassiveDataQueue
 from kuhl_haus.mdp.helpers.process_manager import ProcessManager
+from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
 from kuhl_haus.mdp.helpers.utils import get_massive_api_key
 from kuhl_haus.mdp.helpers.structured_logging import setup_logging
 from pydantic_settings import BaseSettings
@@ -29,7 +30,8 @@ class Settings(BaseSettings):
     rabbitmq_url: str = os.environ.get("RABBITMQ_URL", "amqp://mdq:mdq@localhost:5672/")
 
     # Redis Settings
-    redis_url: str = os.environ.get("REDIS_URL", "redis://mdc:mdc@localhost:6379/0")
+    mdc_redis_url: str = os.environ.get("MDC_REDIS_URL", "redis://mdc:mdc@localhost:6379/0")
+    wdc_redis_url: str = os.environ.get("WDC_REDIS_URL", "redis://mdc:mdc@localhost:6379/1")
 
     # Server Settings
     server_ip: str = os.environ.get("SERVER_IP", "0.0.0.0")
@@ -65,6 +67,11 @@ async def lifespan(app: FastAPI):
     logger.info("Starting Market Data Processor...")
     process_manager = ProcessManager()
 
+    analyzer_options = AnalyzerOptions(
+        redis_url=settings.mdc_redis_url,
+        massive_api_key=settings.massive_api_key,
+    )
+
     # Start MassiveDataProcessors in separate processes
     for i in range(settings.parallelism):
         name = f"mdp_{MassiveDataQueue.AGGREGATE.value}_{i}"
@@ -74,9 +81,9 @@ async def lifespan(app: FastAPI):
             worker_class=MassiveDataProcessor,
             rabbitmq_url=settings.rabbitmq_url,
             queue_name=MassiveDataQueue.AGGREGATE.value,
-            redis_url=settings.redis_url,
-            massive_api_key=settings.massive_api_key,
+            redis_url=settings.wdc_redis_url,
             analyzer_class=LeaderboardAnalyzer,
+            analyzer_options=analyzer_options,
             prefetch_count=settings.prefetch_count,
             max_concurrent_tasks=settings.max_concurrency,
         )
@@ -90,9 +97,9 @@ async def lifespan(app: FastAPI):
             worker_class=MassiveDataProcessor,
             rabbitmq_url=settings.rabbitmq_url,
             queue_name=MassiveDataQueue.TRADES.value,
-            redis_url=settings.redis_url,
-            massive_api_key=settings.massive_api_key,
+            redis_url=settings.wdc_redis_url,
             analyzer_class=TopTradesAnalyzer,
+            analyzer_options=analyzer_options,
             prefetch_count=settings.prefetch_count,
             max_concurrent_tasks=settings.max_concurrency,
         )
@@ -106,9 +113,9 @@ async def lifespan(app: FastAPI):
             worker_class=MassiveDataProcessor,
             rabbitmq_url=settings.rabbitmq_url,
             queue_name=MassiveDataQueue.QUOTES.value,
-            redis_url=settings.redis_url,
-            massive_api_key=settings.massive_api_key,
+            redis_url=settings.wdc_redis_url,
             analyzer_class=MassiveDataAnalyzer,
+            analyzer_options=analyzer_options,
             prefetch_count=settings.prefetch_count,
             max_concurrent_tasks=settings.max_concurrency,
         )
@@ -122,9 +129,9 @@ async def lifespan(app: FastAPI):
             worker_class=MassiveDataProcessor,
             rabbitmq_url=settings.rabbitmq_url,
             queue_name=MassiveDataQueue.HALTS.value,
-            redis_url=settings.redis_url,
-            massive_api_key=settings.massive_api_key,
+            redis_url=settings.wdc_redis_url,
             analyzer_class=MassiveDataAnalyzer,
+            analyzer_options=analyzer_options,
             prefetch_count=settings.prefetch_count,
             max_concurrent_tasks=settings.max_concurrency,
         )

--- a/src/kuhl_haus/servers/wds_server.py
+++ b/src/kuhl_haus/servers/wds_server.py
@@ -22,7 +22,7 @@ class UnauthorizedException(Exception):
 
 class Settings(BaseSettings):
     # Redis Settings
-    redis_url: str = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    wdc_redis_url: str = os.environ.get("WDC_REDIS_URL", "redis://mdc:mdc@localhost:6379/1")
 
     # Server Settings
     server_ip: str = os.environ.get("SERVER_IP", "0.0.0.0")
@@ -82,7 +82,7 @@ async def lifespan(app: FastAPI):
     # Startup
     active_ws_clients.clear()
     redis_client = redis.from_url(
-        settings.redis_url,
+        settings.wdc_redis_url,
         encoding="utf-8",
         decode_responses=True
     )

--- a/tests/servers/test_fdp_server.py
+++ b/tests/servers/test_fdp_server.py
@@ -62,8 +62,12 @@ def test_fdp_settings_with_default_rabbitmq_url_expect_local_amqp():
     assert settings.rabbitmq_url == "amqp://mdq:mdq@localhost:5672/"
 
 
-def test_fdp_settings_with_default_redis_url_expect_local_redis():
-    assert settings.redis_url == "redis://mdc:mdc@localhost:6379/0"
+def test_fdp_settings_with_default_mdc_redis_url_expect_local_redis():
+    assert settings.mdc_redis_url == "redis://mdc:mdc@localhost:6379/0"
+
+
+def test_fdp_settings_with_default_wdc_redis_url_expect_local_redis():
+    assert settings.wdc_redis_url == "redis://mdc:mdc@localhost:6379/1"
 
 
 def test_fdp_settings_with_default_server_port_expect_4204():
@@ -231,7 +235,8 @@ async def test_fdp_root_expect_redirect_to_health(client):
 
 @pytest.mark.parametrize("attr", [
     "rabbitmq_url",
-    "redis_url",
+    "mdc_redis_url",
+    "wdc_redis_url",
     "prefetch_count",
     "max_concurrency",
     "queue_name",


### PR DESCRIPTION
Fixes #48.

Routes each server's Redis connections to the correct cache:

| Server | MDC_REDIS_URL | WDC_REDIS_URL | Notes |
|---|---|---|---|
| `lba_server` | AnalyzerOptions (LeaderboardAnalyzer) | MassiveDataProcessor result storage | |
| `mdp_server` | AnalyzerOptions (all analyzers, shared) | All MassiveDataProcessors | |
| `fdp_server` | AnalyzerOptions (FinlightDataAnalyzer) | FinlightDataProcessor result storage | |
| `wds_server` | — | Widget data reads | |
| `mdl_server` | Removed entirely | Removed entirely | Was POC leftover, never used |

Defaults: `MDC=redis://mdc:mdc@localhost:6379/0`, `WDC=redis://mdc:mdc@localhost:6379/1`

Also pins `kuhl-haus-mdp` to `0.4.0`.