### PR TITLE
feat: add MDS server + pin kuhl-haus-mdp to 0.4.1

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -238,6 +238,31 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # MDS images
+      - name: Build and push MDS Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./mds.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/kuhl-haus-mds-server:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository_owner }}/kuhl-haus-mds-server:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build and push MDS (OTel auto-instrumented) Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./mds_otel.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/kuhl-haus-mds-otel-server:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository_owner }}/kuhl-haus-mds-otel-server:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       # WDS images
       - name: Build and push WDS Docker image
         uses: docker/build-push-action@v6

--- a/mds.Dockerfile
+++ b/mds.Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=python:3.14
+FROM ${BASE_IMAGE}
+WORKDIR /app
+
+COPY . /app/
+
+# Install package and all dependencies from pyproject.toml
+RUN pip install --no-cache-dir .
+
+EXPOSE 4205/tcp
+CMD ["uvicorn", "kuhl_haus.servers.mds_server:app", "--host", "0.0.0.0", "--port", "4205"]

--- a/mds_otel.Dockerfile
+++ b/mds_otel.Dockerfile
@@ -1,0 +1,13 @@
+ARG BASE_IMAGE=python:3.14
+FROM ${BASE_IMAGE}
+WORKDIR /app
+
+COPY . /app/
+
+# Install package and all dependencies from pyproject.toml
+RUN pip install --no-cache-dir .
+RUN pip install opentelemetry-distro
+RUN opentelemetry-bootstrap -a install
+
+EXPOSE 4205/tcp
+CMD ["opentelemetry-instrument", "uvicorn", "kuhl_haus.servers.mds_server:app", "--host", "0.0.0.0", "--port", "4205"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.4.0",
+    "kuhl-haus-mdp==0.4.1",
     "websockets",
     "aio-pika",
     "redis",

--- a/src/kuhl_haus/servers/mds_server.py
+++ b/src/kuhl_haus/servers/mds_server.py
@@ -1,0 +1,120 @@
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Response, status
+from fastapi.responses import RedirectResponse
+from pydantic_settings import BaseSettings
+
+from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+from kuhl_haus.mdp.analyzers.enhanced_quote_analyzer import EnhancedQuoteAnalyzer
+from kuhl_haus.mdp.components.market_data_scanner import MarketDataScanner
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.helpers.structured_logging import setup_logging
+
+
+class Settings(BaseSettings):
+    # Redis Settings (WDC only — MDS never touches MDC)
+    wdc_redis_url: str = os.environ.get("WDC_REDIS_URL", "redis://mdc:mdc@localhost:6379/1")
+
+    # Massive Settings
+    massive_api_key: str = os.environ.get("MASSIVE_API_KEY", "")
+
+    # Server Settings
+    server_ip: str = os.environ.get("SERVER_IP", "0.0.0.0")
+    server_port: int = os.environ.get("SERVER_PORT", 4205)
+    log_level: str = os.environ.get("LOG_LEVEL", "INFO").upper()
+    container_image: str = os.environ.get("CONTAINER_IMAGE", "Unknown")
+    image_version: str = os.environ.get("IMAGE_VERSION", "Unknown")
+
+
+settings = Settings()
+
+setup_logging(settings.log_level)
+logger = logging.getLogger(__name__)
+
+# Global state
+market_data_scanner: MarketDataScanner = None
+scanner_task: asyncio.Task = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Startup and shutdown events"""
+    global market_data_scanner, scanner_task
+
+    logger.info("Starting Market Data Scanner...")
+
+    analyzer_options = AnalyzerOptions(
+        redis_url=settings.wdc_redis_url,
+        massive_api_key=settings.massive_api_key or None,
+    )
+
+    market_data_scanner = MarketDataScanner(
+        redis_url=settings.wdc_redis_url,
+        subscriptions=[f"{WidgetDataCacheKeys.QUOTE.value}:*"],
+        analyzer_class=EnhancedQuoteAnalyzer,
+        analyzer_options=analyzer_options,
+    )
+
+    scanner_task = asyncio.create_task(market_data_scanner.start())
+    logger.info("Market Data Scanner is running.")
+
+    yield
+
+    # Shutdown
+    logger.info("Shutting down Market Data Scanner...")
+    await market_data_scanner.stop()
+    if scanner_task and not scanner_task.done():
+        scanner_task.cancel()
+    logger.info("Market Data Scanner stopped.")
+
+
+app = FastAPI(
+    title="Market Data Scanner",
+    description="Redis pub/sub consumer that performs secondary analysis on market data — event correlation, alert generation, trend analysis, and pattern recognition — through pluggable analyzers.",
+    lifespan=lifespan,
+)
+
+
+@app.get("/")
+async def root():
+    return RedirectResponse(url="/health")
+
+
+@app.get("/health", status_code=200)
+async def health_check(response: Response):
+    """Health check endpoint"""
+    try:
+        return {
+            "service": "Market Data Scanner",
+            "status": "OK",
+            "status_code": 1,
+            "container_image": settings.container_image,
+            "image_version": settings.image_version,
+            "mdc_connected": market_data_scanner.mdc_connected,
+            "running": market_data_scanner.running,
+            "processed": market_data_scanner.processed,
+            "published_results": market_data_scanner.published_results,
+            "empty_results": market_data_scanner.empty_results,
+            "decoding_errors": market_data_scanner.decoding_errors,
+            "errors": market_data_scanner.errors,
+            "restarts": market_data_scanner.restarts,
+        }
+    except Exception as e:
+        logger.error(f"Health check error: {e}")
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {
+            "service": "Market Data Scanner",
+            "status": "ERROR",
+            "status_code": 0,
+            "container_image": settings.container_image,
+            "image_version": settings.image_version,
+            "message": "An unhandled exception occurred during health check.",
+        }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=4205)

--- a/tests/servers/test_mds_server.py
+++ b/tests/servers/test_mds_server.py
@@ -1,0 +1,217 @@
+"""Unit tests for kuhl_haus.servers.mds_server.
+
+Run:
+    pytest tests/servers/test_mds_server.py -v
+"""
+import pytest
+from asgi_lifespan import LifespanManager
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import AsyncClient, ASGITransport
+
+MODULE = "kuhl_haus.servers.mds_server"
+
+from kuhl_haus.servers.mds_server import app, settings  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_scanner():
+    mock = AsyncMock()
+    mock.mdc_connected = True
+    mock.running = True
+    mock.processed = 0
+    mock.published_results = 0
+    mock.empty_results = 0
+    mock.decoding_errors = 0
+    mock.errors = 0
+    mock.restarts = 0
+    mock.start = AsyncMock()
+    mock.stop = AsyncMock()
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def client():
+    """AsyncClient with mocked MarketDataScanner."""
+    mock_scanner = _make_mock_scanner()
+
+    with patch(f"{MODULE}.MarketDataScanner", return_value=mock_scanner):
+        async with LifespanManager(app):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as ac:
+                yield ac, mock_scanner
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+def test_mds_settings_with_default_wdc_redis_url_expect_local_redis_db1():
+    assert settings.wdc_redis_url == "redis://mdc:mdc@localhost:6379/1"
+
+
+def test_mds_settings_with_default_server_port_expect_4205():
+    assert settings.server_port == 4205
+
+
+def test_mds_settings_with_default_log_level_expect_info():
+    assert settings.log_level == "INFO"
+
+
+def test_mds_settings_with_default_massive_api_key_expect_empty():
+    assert settings.massive_api_key == ""
+
+
+@pytest.mark.parametrize("attr", [
+    "wdc_redis_url",
+    "massive_api_key",
+    "server_ip",
+    "server_port",
+    "log_level",
+    "container_image",
+    "image_version",
+])
+def test_mds_settings_with_attr_expect_exists(attr):
+    assert hasattr(settings, attr)
+
+
+# ---------------------------------------------------------------------------
+# Lifespan — startup
+# ---------------------------------------------------------------------------
+
+async def test_mds_lifespan_with_default_settings_expect_scanner_started():
+    mock_scanner = _make_mock_scanner()
+
+    with patch(f"{MODULE}.MarketDataScanner", return_value=mock_scanner) as mock_cls:
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    mock_cls.assert_called_once()
+    mock_scanner.start.assert_awaited_once()
+
+
+async def test_mds_lifespan_with_default_settings_expect_wdc_redis_url_passed():
+    mock_scanner = _make_mock_scanner()
+
+    with patch(f"{MODULE}.MarketDataScanner", return_value=mock_scanner) as mock_cls:
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    call_kwargs = mock_cls.call_args.kwargs
+    assert call_kwargs["redis_url"] == settings.wdc_redis_url
+
+
+async def test_mds_lifespan_with_default_settings_expect_quote_subscription():
+    mock_scanner = _make_mock_scanner()
+
+    with patch(f"{MODULE}.MarketDataScanner", return_value=mock_scanner) as mock_cls:
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    call_kwargs = mock_cls.call_args.kwargs
+    subscriptions = call_kwargs["subscriptions"]
+    assert any("quote" in s for s in subscriptions)
+
+
+async def test_mds_lifespan_with_default_settings_expect_enhanced_quote_analyzer():
+    from kuhl_haus.mdp.analyzers.enhanced_quote_analyzer import EnhancedQuoteAnalyzer
+    mock_scanner = _make_mock_scanner()
+
+    with patch(f"{MODULE}.MarketDataScanner", return_value=mock_scanner) as mock_cls:
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    call_kwargs = mock_cls.call_args.kwargs
+    assert call_kwargs["analyzer_class"] is EnhancedQuoteAnalyzer
+
+
+# ---------------------------------------------------------------------------
+# Lifespan — shutdown
+# ---------------------------------------------------------------------------
+
+async def test_mds_lifespan_shutdown_expect_scanner_stopped():
+    mock_scanner = _make_mock_scanner()
+
+    with patch(f"{MODULE}.MarketDataScanner", return_value=mock_scanner):
+        async with LifespanManager(app):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test"):
+                pass
+
+    mock_scanner.stop.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+async def test_mds_health_with_scanner_running_expect_200(client):
+    ac, _ = client
+    response = await ac.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "OK"
+    assert body["status_code"] == 1
+
+
+async def test_mds_health_expect_service_name_market_data_scanner(client):
+    ac, _ = client
+    response = await ac.get("/health")
+    assert response.json()["service"] == "Market Data Scanner"
+
+
+async def test_mds_health_expect_scanner_stats_in_response(client):
+    ac, mock_scanner = client
+    mock_scanner.processed = 100
+    mock_scanner.published_results = 95
+    mock_scanner.errors = 2
+
+    response = await ac.get("/health")
+    body = response.json()
+    assert "processed" in body
+    assert "published_results" in body
+    assert "errors" in body
+    assert "mdc_connected" in body
+    assert "running" in body
+
+
+async def test_mds_health_expect_container_image_and_version(client):
+    ac, _ = client
+    response = await ac.get("/health")
+    body = response.json()
+    assert "container_image" in body
+    assert "image_version" in body
+
+
+async def test_mds_health_with_exception_expect_503(client):
+    ac, mock_scanner = client
+    # Simulate health check error by making mdc_connected raise
+    type(mock_scanner).mdc_connected = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    response = await ac.get("/health")
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "ERROR"
+    assert body["status_code"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /
+# ---------------------------------------------------------------------------
+
+async def test_mds_root_expect_redirect_to_health(client):
+    ac, _ = client
+    response = await ac.get("/", follow_redirects=False)
+    assert response.status_code in (301, 302, 307, 308)
+    assert "/health" in response.headers.get("location", "")


### PR DESCRIPTION
Adds the Market Data Scanner server — the first MDS deployment unit.

**`mds_server.py`** follows the FDP pattern:
- `BaseSettings` with `WDC_REDIS_URL`, `MASSIVE_API_KEY`, `SERVER_PORT=4205`
- `asynccontextmanager` lifespan wires `MarketDataScanner` + `EnhancedQuoteAnalyzer`
- Subscribes to `quote:*` on WDC pub/sub
- `/health` returns scanner metrics; `/` redirects to `/health`
- WDC only — MDC is never referenced

**Dockerfiles:** `mds.Dockerfile` + `mds_otel.Dockerfile` on port 4205.

**pyproject.toml:** pinned to `kuhl-haus-mdp==0.4.1` (includes `EnhancedQuoteAnalyzer`).

refs #51