### PR TITLE
chore: pin kuhl-haus-mdp to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.4.1",
+    "kuhl-haus-mdp==0.4.2",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Pins to v0.4.2 which fixes the enrichment cache poison bug (kuhl-haus-mdp#85/#87) — self-healing retry TTL and empty sentinel memory trap fix.