### PR TITLE
chore: bump kuhl-haus-mdp to 0.4.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.4.3",
+    "kuhl-haus-mdp==0.4.4",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Pin to kuhl-haus-mdp==0.4.4, which includes enrichment fixes for the EnhancedQuoteAnalyzer.

refs kuhl-haus/kuhl-haus-mdp#85