### PR TITLE
feat: switch MDS from EnhancedQuoteAnalyzer to DailyRangeAnalyzer

### DIFF
--- a/src/kuhl_haus/servers/mds_server.py
+++ b/src/kuhl_haus/servers/mds_server.py
@@ -8,7 +8,7 @@ from fastapi.responses import RedirectResponse
 from pydantic_settings import BaseSettings
 
 from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
-from kuhl_haus.mdp.analyzers.enhanced_quote_analyzer import EnhancedQuoteAnalyzer
+from kuhl_haus.mdp.analyzers.daily_range_analyzer import DailyRangeAnalyzer
 from kuhl_haus.mdp.components.market_data_scanner import MarketDataScanner
 from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
 from kuhl_haus.mdp.helpers.structured_logging import setup_logging
@@ -54,7 +54,7 @@ async def lifespan(app: FastAPI):
     market_data_scanner = MarketDataScanner(
         redis_url=settings.wdc_redis_url,
         subscriptions=[f"{WidgetDataCacheKeys.QUOTE.value}:*"],
-        analyzer_class=EnhancedQuoteAnalyzer,
+        analyzer_class=DailyRangeAnalyzer,
         analyzer_options=analyzer_options,
     )
 

--- a/tests/servers/test_mds_server.py
+++ b/tests/servers/test_mds_server.py
@@ -124,8 +124,8 @@ async def test_mds_lifespan_with_default_settings_expect_quote_subscription():
     assert any("quote" in s for s in subscriptions)
 
 
-async def test_mds_lifespan_with_default_settings_expect_enhanced_quote_analyzer():
-    from kuhl_haus.mdp.analyzers.enhanced_quote_analyzer import EnhancedQuoteAnalyzer
+async def test_mds_lifespan_with_default_settings_expect_daily_range_analyzer():
+    from kuhl_haus.mdp.analyzers.daily_range_analyzer import DailyRangeAnalyzer
     mock_scanner = _make_mock_scanner()
 
     with patch(f"{MODULE}.MarketDataScanner", return_value=mock_scanner) as mock_cls:
@@ -134,7 +134,7 @@ async def test_mds_lifespan_with_default_settings_expect_enhanced_quote_analyzer
                 pass
 
     call_kwargs = mock_cls.call_args.kwargs
-    assert call_kwargs["analyzer_class"] is EnhancedQuoteAnalyzer
+    assert call_kwargs["analyzer_class"] is DailyRangeAnalyzer
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Wires up `DailyRangeAnalyzer` in the MDS server. No REST API calls in the hot path — pure HOD/LOD tracking from the `quote:*` feed, publishing to `daily_range:{symbol}`.

refs kuhl-haus/kuhl-haus-mdp#91