### PR TITLE
chore: relax Python floor from 3.14 to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Tom Pounders", email = "git@oldschool.engineer" },
 ]
 readme = "README.rst"
-requires-python = ">=3.14"
+requires-python = ">=3.12"
 license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Consistent with kuhl-haus/kuhl-haus-mdp#94. Dropping the Python floor from 3.14 to 3.12 to align with kuhl-haus-mdp-app runtime.