### PR TITLE
Bump kuhl-haus-mdp to version 0.4.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "kuhl-haus-mdp==0.4.12",
+    "kuhl-haus-mdp==0.4.13",
     "websockets",
     "aio-pika",
     "redis",


### PR DESCRIPTION
Pins `kuhl-haus-mdp` to `0.4.13` in `pyproject.toml`.